### PR TITLE
Add sub_device_price for subscription plans and Visa checkout param

### DIFF
--- a/_data/products.yaml
+++ b/_data/products.yaml
@@ -19,6 +19,9 @@
       MYR: 175.00
     deposit:
       MYR: 1999.00
+    # Total subscription plan value (deposit + all monthly payments); not the same as gateway `amount`
+    sub_device_price:
+      MYR: 6199.00
 
 - name: Sim Card
   category: Add-on

--- a/_data/promotions.yaml
+++ b/_data/promotions.yaml
@@ -6,6 +6,7 @@
 # subscription:
 #   - single currency: currency: MYR, monthly_price: 120.00
 #   - multi currency:  monthly_prices: { MYR: 120.00 }
+#   - sub_device_price: { MYR: ... } total plan value for subscriptions (optional; overrides product)
 
 - product: KommuAssist2
   type: one_off
@@ -27,3 +28,5 @@
     MYR: 175.00
   deposit:
     MYR: 1599.00
+  sub_device_price:
+    MYR: 5799.00

--- a/_includes/pricing_helpers.html
+++ b/_includes/pricing_helpers.html
@@ -160,6 +160,47 @@
     return out;
   }
 
+  function getSubscriptionMonths(curr, labels){
+    const ccy = (curr||'').toUpperCase();
+    let months = 24;
+    try{
+      const dev = (products||[]).find(p => (p.name||'').toLowerCase()==='kommuassist2');
+      if (dev?.subscription) months = parseInt(dev.subscription.month || 24, 10) || 24;
+    } catch(_) {}
+    const subPromo = getSubscriptionPromoFromLabels(labels, curr);
+    if (subPromo && subPromo.months) months = subPromo.months;
+    return months;
+  }
+
+  /**
+   * Total amount attributed to the subscription plan (deposit + all instalments),
+   * separate from the one-off `amount` sent to the payment gateway.
+   * Optional `resolved`: { deposit, monthly, months } from checkout (promo overrides applied).
+   */
+  function getSubDevicePriceByCurrency(curr, labels, resolved){
+    const ccy = (curr||'').toUpperCase();
+    const promo = Array.isArray(labels) && labels.length
+      ? activePromoFor('KommuAssist2','subscription',ccy,labels) : null;
+    if (promo && promo.sub_device_price != null){
+      if (typeof promo.sub_device_price === 'object' && promo.sub_device_price[ccy] != null)
+        return parseFloat(promo.sub_device_price[ccy]) || 0;
+      if (promo.currency && (promo.currency||'').toUpperCase()===ccy && typeof promo.sub_device_price !== 'object')
+        return parseFloat(promo.sub_device_price) || 0;
+    }
+    try{
+      const dev = (products||[]).find(p => (p.name||'').toLowerCase() === 'kommuassist2');
+      const map = dev?.subscription?.sub_device_price;
+      if (map && map[ccy] != null) return parseFloat(map[ccy]) || 0;
+    } catch(_) {}
+    const dep = resolved && typeof resolved.deposit === 'number' && !Number.isNaN(resolved.deposit)
+      ? resolved.deposit : getDeviceDepositByCurrency(ccy, labels);
+    const mon = resolved && typeof resolved.monthly === 'number' && !Number.isNaN(resolved.monthly)
+      ? resolved.monthly : getDeviceMonthlyByCurrency(ccy, labels);
+    const mos = resolved && typeof resolved.months === 'number' && !Number.isNaN(resolved.months) && resolved.months > 0
+      ? resolved.months : getSubscriptionMonths(curr, labels);
+    return (dep || 0) + (mon || 0) * (mos || 0);
+  }
+
   // ----- Rules matcher (for product/cart flows)
   function matchRule(ctx){
     const cfg = (rulesConfig && rulesConfig.rules) ? rulesConfig.rules : (Array.isArray(rulesConfig) ? rulesConfig : []);
@@ -204,6 +245,7 @@
     getPreferredLocale, getCurrencyCode, getFormatter,
     getProductPriceByNameCurrency, getBaseDevicePriceByCurrency,
     getDevicePriceByCurrency, getDeviceMonthlyByCurrency, getDeviceDepositByCurrency,
+    getSubDevicePriceByCurrency, getSubscriptionMonths,
     matchRule, getAddonSurchargeFromSelections, getSubscriptionPromoFromLabels, getSlashedDevicePriceByCurrency, getSSTDevicePriceByCurrency
   };
 

--- a/checkout.html
+++ b/checkout.html
@@ -297,7 +297,14 @@ title: Checkout
           }
         }
 
-        return { thenBlock, promoLabels, deviceOneOff, deviceMonthly: (typeof _monthlyOverride === 'number' ? _monthlyOverride : deviceMonthly), bundled, months, subscriptionId, deposit };
+        const monthlyResolved = (typeof _monthlyOverride === 'number' ? _monthlyOverride : deviceMonthly);
+        const subDevicePrice = KommuPricing.getSubDevicePriceByCurrency(currency, promoLabels, {
+          deposit,
+          monthly: monthlyResolved,
+          months
+        });
+
+        return { thenBlock, promoLabels, deviceOneOff, deviceMonthly: monthlyResolved, bundled, months, subscriptionId, deposit, subDevicePrice };
 
     }
   }
@@ -964,6 +971,7 @@ function checkoutSubmit() {
     params.append("subscription",     subscriptionId);
     params.append("harness",          selections.model || "");
     params.append("amount",           devicePrice.toFixed(2));
+    params.append("sub_device_price", (pricing.subDevicePrice != null ? Number(pricing.subDevicePrice) : 0).toFixed(2));
     params.append("monthlyPayment",   monthlyPayment);
     params.append("deposit",          depositAmount);
     params.append("installation",     selections.install || "");


### PR DESCRIPTION
Introduce subscription plan total (sub_device_price) in product and promo data, resolve it in pricing helpers with promo/month consistency, and pass sub_device_price on rent-to-own Visa URLs while keeping amount as gateway device total.
